### PR TITLE
Handle split size frames

### DIFF
--- a/src/chumak_protocol.erl
+++ b/src/chumak_protocol.erl
@@ -116,7 +116,7 @@ decode(#decoder{state=ready}=Decoder, Frame) ->
             require_size(Decoder, 2, Frame, ready);
 
         %% if size is remaing for large frame
-        <<_:5, _:1, 1:1, _:1>> ->
+        <<_:5, _:1, 1:1, _:1, _TooShortToBeSize/binary>> ->
             require_size(Decoder, 9, Frame, ready);
 
         X ->


### PR DESCRIPTION
We were seeing this decoding error:

```
2017-01-13 03:18:45.092 [error] <0.3412.0> decode_fail, reason: {bad_ready_packet,<<3,0,0,0,0,0,0,3>>}
2017-01-13 03:18:45.092 [error] <0.3412.0> gen_server <0.3412.0> terminated with reason: decode_error
2017-01-13 03:18:45.092 [error] <0.3412.0> CRASH REPORT Process <0.3412.0> with 0 neighbours exited with reason: decode_error in gen_server:terminate/7 line 812
2017-01-13 03:18:45.097 [info] <0.3379.0> unhandled_handle_info, module: chumak_socket, msg: {'EXIT',<0.3412.0>,decode_error}
```

After messing unsuccessfully with `inet:setopts` and increasing `buffer`, we ended up with this workaround that makes it tolerant of truncated size frames.